### PR TITLE
Added balancing players without rank by their summoner level

### DIFF
--- a/craftersmine.LeagueBalancer/Balancer.cs
+++ b/craftersmine.LeagueBalancer/Balancer.cs
@@ -19,11 +19,17 @@ namespace craftersmine.LeagueBalancer
         {
             List<Summoner> blueTeam = new List<Summoner>();
             List<Summoner> redTeam = new List<Summoner>();
-            
+
             int blueTeamLp = 0;
             int redTeamLp = 0;
 
+            int blueTeamLevel = 0;
+            int redTeamLevel = 0;
+
             List<Summoner> orderedSummoners = summoners.OrderBy(s => s.LeaguePointsAmount).ToList();
+            List<Summoner> unrankedSummoners =
+                orderedSummoners.Where(s => s.SummonerLeague is null || s.SummonerLeague?.Tier == LeagueRankedTier.Unranked).OrderBy(s => s.SummonerInfo.SummonerLevel).ToList();
+            orderedSummoners.RemoveAll(s => s.SummonerLeague is null || s.SummonerLeague?.Tier == LeagueRankedTier.Unranked);
 
             while (orderedSummoners.Any())
             {
@@ -40,6 +46,24 @@ namespace craftersmine.LeagueBalancer
                     redTeam.Add(summoner);
                     orderedSummoners.Remove(summoner);
                     redTeamLp += summoner.LeaguePointsAmount;
+                }
+            }
+
+            while (unrankedSummoners.Any())
+            {
+                Summoner summoner = unrankedSummoners.MaxBy(s => s.SummonerInfo.SummonerLevel);
+
+                if (blueTeamLevel < redTeamLevel && blueTeam.Count < 5)
+                {
+                    blueTeam.Add(summoner);
+                    unrankedSummoners.Remove(summoner);
+                    blueTeamLevel += (int)summoner.SummonerInfo.SummonerLevel;
+                }
+                else
+                {
+                    redTeam.Add(summoner);
+                    unrankedSummoners.Remove(summoner);
+                    redTeamLevel += (int)summoner.SummonerInfo.SummonerLevel;
                 }
             }
 

--- a/craftersmine.LeagueBalancer/Balancer.cs
+++ b/craftersmine.LeagueBalancer/Balancer.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 
 using craftersmine.League.CommunityDragon;
-using craftersmine.Riot.Api.Common;
 using craftersmine.Riot.Api.League.Mastery;
+using craftersmine.Riot.Api.League.SummonerLeagues;
 
 namespace craftersmine.LeagueBalancer
 {

--- a/craftersmine.LeagueBalancer/Balancer.cs
+++ b/craftersmine.LeagueBalancer/Balancer.cs
@@ -21,8 +21,7 @@ namespace craftersmine.LeagueBalancer
         {
             List<Summoner> blueTeam = new List<Summoner>();
             List<Summoner> redTeam = new List<Summoner>();
-
-            int averageLp = (int)summoners.Average(s => s.LeaguePointsAmount);
+            
             int blueTeamLp = 0;
             int redTeamLp = 0;
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Fixes team balancing being 100% onesided when players have no ranked ratings

Any other comments?
-------------------
Balancing by their summoner level can be quite unfair due to smurfing accounts, etc. This is implemented only to accomodate League season changes with their ranks resets
