### PR TITLE
Added RiotID in summoners list

### DIFF
--- a/craftersmine.LeagueBalancer/App.xaml.cs
+++ b/craftersmine.LeagueBalancer/App.xaml.cs
@@ -17,7 +17,7 @@ namespace craftersmine.LeagueBalancer
 {
     public partial class App : Application
     {
-        public static readonly Version CurrentVersion = new Version(1, 1, 5);
+        public static readonly Version CurrentVersionPredefined = new Version(1, 1, 5);
 
         public static RiotApiClientSettings ClientSettings { get; private set; }
 
@@ -27,6 +27,8 @@ namespace craftersmine.LeagueBalancer
         public static RiotAccountApiClient RiotAccountApiClient { get; private set; }
 
         public static CommunityDragon CommunityDragonClient { get; private set; }
+
+        public static Version CurrentVersion => System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
 
         protected override void OnStartup(StartupEventArgs e)
         {

--- a/craftersmine.LeagueBalancer/App.xaml.cs
+++ b/craftersmine.LeagueBalancer/App.xaml.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Windows;
 using craftersmine.League.CommunityDragon;
+using craftersmine.Riot.Api.Account;
 using craftersmine.Riot.Api.Common;
 using craftersmine.Riot.Api.League.Mastery;
 using craftersmine.Riot.Api.League.Summoner;
@@ -23,6 +24,7 @@ namespace craftersmine.LeagueBalancer
         public static LeagueSummonerApiClient SummonerApiClient { get; private set; }
         public static LeagueSummonerLeaguesApiClient SummonerLeaguesApiClient { get; private set; }
         public static LeagueMasteryApiClient MasteryApiClient { get; private set; }
+        public static RiotAccountApiClient RiotAccountApiClient { get; private set; }
 
         public static CommunityDragon CommunityDragonClient { get; private set; }
 
@@ -38,6 +40,7 @@ namespace craftersmine.LeagueBalancer
             SummonerApiClient = new LeagueSummonerApiClient(ClientSettings);
             SummonerLeaguesApiClient = new LeagueSummonerLeaguesApiClient(ClientSettings);
             MasteryApiClient = new LeagueMasteryApiClient(ClientSettings);
+            RiotAccountApiClient = new RiotAccountApiClient(ClientSettings);
 
             CommunityDragonClient = new CommunityDragon(VersionAlias.Latest, LeagueLocales.English);
 

--- a/craftersmine.LeagueBalancer/MainWindow.xaml
+++ b/craftersmine.LeagueBalancer/MainWindow.xaml
@@ -100,7 +100,11 @@
                             </Grid.RowDefinitions>
                             <leagueuicontrols:UserPicture Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" ImageSource="{Binding Icon}"/>
                             <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Margin="10 2 0 0">
-                                <TextBlock Text="{Binding SummonerInfo.Name}" VerticalAlignment="Center"/>
+                                <TextBlock VerticalAlignment="Center">
+                                    <Run Text="{Binding RiotId}"/>
+                                    <Run Text="#"/>
+                                    <Run Text="{Binding TagLine}"/>
+                                </TextBlock>
                                 <TextBlock Text="{Binding Region.RegionName}" VerticalAlignment="Center" Margin="8 0 0 0" Style="{StaticResource LeagueOfflineText}" FontSize="10pt"/>
                                 <TextBlock Text="Lvl:" VerticalAlignment="Center" Margin="8 0 0 0" Style="{StaticResource LeagueOfflineText}" FontSize="10pt"/>
                                 <TextBlock Text="{Binding SummonerInfo.SummonerLevel}" VerticalAlignment="Center" Margin="4 0 0 0" Style="{StaticResource LeagueOfflineText}" FontSize="10pt"/>

--- a/craftersmine.LeagueBalancer/Summoner.cs
+++ b/craftersmine.LeagueBalancer/Summoner.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-
+using craftersmine.Riot.Api.Account;
 using craftersmine.Riot.Api.Common;
 using craftersmine.Riot.Api.League.Summoner;
 using craftersmine.Riot.Api.League.SummonerLeagues;
@@ -22,6 +22,8 @@ namespace craftersmine.LeagueBalancer
         private SummonerLeague _summonerLeague;
         private string _summonerLeagueString;
         private int _lpAmount;
+        private string _tagLine;
+        private string _riotId;
 
         public Uri IconUri
         {
@@ -85,6 +87,26 @@ namespace craftersmine.LeagueBalancer
             }
         }
 
+        public string TagLine
+        {
+            get => _tagLine;
+            set
+            {
+                _tagLine = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string RiotId
+        {
+            get => _riotId;
+            set
+            {
+                _riotId = value;
+                OnPropertyChanged();
+            }
+        }
+
         public Summoner(LeagueSummoner summoner, LeagueRegion region)
         {
             SummonerLeagueString = "Unranked (0 LP)";
@@ -143,6 +165,10 @@ namespace craftersmine.LeagueBalancer
 
             IconUri = new Uri(AppCache.Instance.Icons[SummonerInfo.ProfileIconId].GetAssetUri());
             Icon = new BitmapImage(IconUri);
+
+            RiotAccount account = await App.RiotAccountApiClient.GetAccountByPuuidAsync(SummonerInfo.RiotPuuid);
+            TagLine = account.RiotIdTag;
+            RiotId = account.RiotId;
         }
 
         public static int CalculateLpValue(LeagueRankedTier tier, LeagueDivisionRank division, int currentLp)

--- a/craftersmine.LeagueBalancer/craftersmine.LeagueBalancer.csproj
+++ b/craftersmine.LeagueBalancer/craftersmine.LeagueBalancer.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <Company>craftersmine</Company>
-    <Version>1.1.5</Version>
+    <Version>1.1.6</Version>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <IsPublishable>False</IsPublishable>
   </PropertyGroup>

--- a/craftersmine.LeagueBalancer/craftersmine.LeagueBalancer.csproj
+++ b/craftersmine.LeagueBalancer/craftersmine.LeagueBalancer.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="craftersmine.League.CommunityDragon" Version="0.3.2-dev" />
+    <PackageReference Include="craftersmine.Riot.Api.Account" Version="0.2.1-dev" />
     <PackageReference Include="craftersmine.Riot.Api.League.Mastery" Version="0.2.1-dev" />
     <PackageReference Include="craftersmine.Riot.Api.League.SummonerLeagues" Version="0.2.1-dev" />
     <PackageReference Include="craftersmine.Ui.League" Version="1.1.4" />


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Due to new RiotID changes in League of Legends, app now shows full RiotID with tag line in lists.

Does this close any currently open issues?
------------------------------------------
No, this is a QoL change

Where has this been tested?
---------------------------
**Operating System:** Windows 11 x64 23H2 Release Channel

**Platform:** .NET 6.0.414 x64

**App version:** 1.1.6
