### PR TITLE
Fixed mastery generator

### DIFF
--- a/craftersmine.LeagueBalancer/Balancer.cs
+++ b/craftersmine.LeagueBalancer/Balancer.cs
@@ -82,7 +82,7 @@ namespace craftersmine.LeagueBalancer
                 AppCache.Instance.Champions = await App.CommunityDragonClient.GetChampionsAsync();
 
             LeagueChampionMastery[] masteries =
-                await App.MasteryApiClient.GetMasteriesBySummonerId(summoner.Region.Region, summoner.SummonerInfo.Id);
+                await App.MasteryApiClient.GetMasteriesByPuuid(summoner.Region.Region, summoner.SummonerInfo.RiotPuuid);
 
             LeagueChampionMastery maxMastery = masteries.MaxBy(m => m.MasteryPoints)!;
 

--- a/craftersmine.LeagueBalancer/craftersmine.LeagueBalancer.csproj
+++ b/craftersmine.LeagueBalancer/craftersmine.LeagueBalancer.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <Company>craftersmine</Company>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <IsPublishable>False</IsPublishable>
   </PropertyGroup>
@@ -21,10 +21,10 @@
 
   <ItemGroup>
     <PackageReference Include="craftersmine.League.CommunityDragon" Version="0.3.2-dev" />
-    <PackageReference Include="craftersmine.Riot.Api.Account" Version="0.2.1-dev" />
-    <PackageReference Include="craftersmine.Riot.Api.League.Mastery" Version="0.2.1-dev" />
-    <PackageReference Include="craftersmine.Riot.Api.League.SummonerLeagues" Version="0.2.1-dev" />
-    <PackageReference Include="craftersmine.Ui.League" Version="1.2.0" />
+    <PackageReference Include="craftersmine.Riot.Api.Account" Version="0.3.0-dev" />
+    <PackageReference Include="craftersmine.Riot.Api.League.Mastery" Version="0.3.0-dev" />
+    <PackageReference Include="craftersmine.Riot.Api.League.SummonerLeagues" Version="0.3.0-dev" />
+    <PackageReference Include="craftersmine.Ui.League" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixed issue when generating mastery due to broken Riot API. Mastery API's with summoner ID endpoints were early deprecated in December 2023 instead of January 2024

Any relevant logs, error output, etc?
-------------------------------------
Riot API returns "Endpoint not exists" error when requesting mastery

Where has this been tested?
---------------------------
**Operating System:** Windows 11 x64 23H2 Release Channel

**Platform:** .NET 6

**App version:** 1.2.3
