### PR TITLE
Fixed issue with missing names in balanced lists

### DIFF
--- a/craftersmine.LeagueBalancer/MainWindow.xaml
+++ b/craftersmine.LeagueBalancer/MainWindow.xaml
@@ -23,7 +23,7 @@
                 <Run Text="{x:Static localization:Locale.MainWindow_Disclaimer}"/>
             </TextBlock>
         </Grid>
-        
+
     </leagueuicontrols:LeagueWindow.Header>
     <leagueuicontrols:LeagueWindow.Background>
         <VisualBrush>
@@ -161,7 +161,7 @@
                               Tag="{x:Static local:LeagueTeamType.Blue}">
                         <ListView.ItemTemplate>
                             <DataTemplate DataType="{x:Type local:Summoner}">
-                                <Grid Width="100">
+                                <Grid Width="Auto">
                                     <Grid.RowDefinitions>
                                         <RowDefinition/>
                                         <RowDefinition/>
@@ -173,7 +173,12 @@
                                             </Ellipse.Fill>
                                         </Ellipse>
                                     </Border>
-                                    <TextBlock Grid.Row="1" HorizontalAlignment="Center" Margin="4" Text="{Binding SummonerInfo.Name}" TextWrapping="Wrap"/>
+                                    <TextBlock Grid.Row="1" HorizontalAlignment="Center" Margin="4" TextWrapping="Wrap">
+
+                                    <Run Text="{Binding RiotAccount.RiotId, Mode=OneWay}"/>
+                                    <Run Text="#"/>
+                                    <Run Text="{Binding RiotAccount.RiotIdTag, Mode=OneWay}"/>
+                                    </TextBlock>
                                 </Grid>
                             </DataTemplate>
                         </ListView.ItemTemplate>
@@ -195,7 +200,7 @@
                               Tag="{x:Static local:LeagueTeamType.Red}">
                         <ListView.ItemTemplate>
                             <DataTemplate DataType="{x:Type local:Summoner}">
-                                <Grid Width="100">
+                                <Grid Width="Auto">
                                     <Grid.RowDefinitions>
                                         <RowDefinition/>
                                         <RowDefinition/>
@@ -207,7 +212,12 @@
                                             </Ellipse.Fill>
                                         </Ellipse>
                                     </Border>
-                                    <TextBlock Grid.Row="1" HorizontalAlignment="Center" Margin="4" Text="{Binding SummonerInfo.Name}" TextWrapping="Wrap"/>
+                                    <TextBlock Grid.Row="1" HorizontalAlignment="Center" Margin="4" TextWrapping="Wrap">
+
+                                    <Run Text="{Binding RiotAccount.RiotId, Mode=OneWay}"/>
+                                    <Run Text="#"/>
+                                    <Run Text="{Binding RiotAccount.RiotIdTag, Mode=OneWay}"/>
+                                    </TextBlock>
                                 </Grid>
                             </DataTemplate>
                         </ListView.ItemTemplate>

--- a/craftersmine.LeagueBalancer/craftersmine.LeagueBalancer.csproj
+++ b/craftersmine.LeagueBalancer/craftersmine.LeagueBalancer.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <Company>craftersmine</Company>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <IsPublishable>False</IsPublishable>
   </PropertyGroup>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes missing names in balanced summoner lists in the window center

Any other comments?
-------------------
It's related to Riot.API library, and changed Riot API that allows to request that data

Where has this been tested?
---------------------------
**Operating System:** Windows 11 x64 23H2 Release Channel

**Platform:** .NET 6.0.414

**App version:** 1.3.1
